### PR TITLE
utility get theme can return null now

### DIFF
--- a/utils/getTheme.ts
+++ b/utils/getTheme.ts
@@ -1,7 +1,6 @@
 export const utilityGetTheme = () => {
   if (typeof window !== "undefined") {
-    const theme =
-      localStorage.getItem("startuppario-bitrocket-theme") || "light";
-    return JSON.parse(theme);
+    const theme = localStorage.getItem("startuppario-bitrocket-theme");
+    return theme ? JSON.parse(theme) : null;
   }
 };


### PR DESCRIPTION
## Descrizione
la funzione di utility può tornare null


## Domande/commenti al revisore
La funzione di utility getTheme cercava la chiave "startuppario-bitrocket-theme" oppure light, ma doveva trovare la chiave e tornare il valore altrimenti doveva tornare null, cosicché lo useState potesse utilizzare il valore di default light

_Per favore indicare se ci sono cose di cui essere a conoscenza o cose su cui hai bisogno di input_

## Tipologia di cambiamento - selezionare il tipo di cambiamento pertinente:

- [ X ] 🐛 Bug fix (cambiamento non critico che risolve un problema)
- [ ] 🆕 New feature (cambiamento non critico che aggiunge funzionalità)
- [ ] 💄 Adjustment (regolazione visiva o semplici regolazioni logiche)
- [ ] 💥 Breaking change (correzione o funzionalità che potrebbero causare il mancato funzionamento di quelle esistenti come previsto)

## Testati su - selezionare il tipo di dispositivo pertinente:

- [ X ] Chrome
- [ ] Firefox
- [ ] Brave

## Come testare - includi un elenco di cose da testare

Svuotare lo storage e refreshare la pagina

### Screenshots, registrazioni video 📸 👇

https://user-images.githubusercontent.com/85617777/203011693-235ab5b2-3999-4ca0-bf32-7a6b2808e6f9.mp4



